### PR TITLE
Fixing bug where multi-part torrents were saving to working directory

### DIFF
--- a/PyBitTorrent/PiecesManager.py
+++ b/PyBitTorrent/PiecesManager.py
@@ -10,10 +10,17 @@ class DiskManager:
         self.torrent = torrent
         self.written = 0
         self.multi_part = "files" in self.torrent.info.keys()
+        logging.getLogger("BitTorrent").debug(f"DiskManager output directory is {output_directory}")
+
+        # Ensure output directory exists
+        os.makedirs(output_directory, exist_ok=True)
+
         if self.multi_part:
             self.file = tempfile.TemporaryFile()
         else:
-            self.file = open(self.torrent.file_name, "wb")  # Regular one single file
+            # Update to use output_directory for single file torrent
+            file_path = os.path.join(output_directory, self.torrent.file_name)
+            self.file = open(file_path, "wb")
 
     def write_piece(self, piece, piece_size):
         """
@@ -33,14 +40,15 @@ class DiskManager:
         """
         # If torrent contain multiple file, split them
         if self.multi_part:
-            self.file.seek(0)  # We start reading the file from the beginning
+            self.file.seek(0)
             for file in self.torrent.info['files']:
-                # Calculate the full path of each file
-                file_path = self.torrent.file_name  # We start from the directory name
+                # Calculate the full path of each file including the output_directory
+                file_path = os.path.join(self.output_directory, self.torrent.file_name)
                 for entity in file['path']:
                     file_path = os.path.join(file_path, entity)
 
-                logging.getLogger("BitTorrent").debug(f"Writing to file {file_path}")
+                logging.getLogger("BitTorrent").debug(f"Def close file path is {file_path}")
+                logging.getLogger("BitTorrent").debug(f"Diskmanager output directory is {file_path}")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)  # Create directories if necessary
                 logging.getLogger("BitTorrent").debug(f"Writing data in offsets {self.file.tell()}:{file['length']}")
 


### PR DESCRIPTION
Multi part torrents were not respecting "output directory" parameter

Feel free to remove added logging.